### PR TITLE
fix: update version in index.md to 0.8.0-draft

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ UAAPS is the open standard for packaging AI agent artifacts — analogous to Doc
 
 ## Current Version
 
-**0.6.0-draft** — See the [Changelog](changelog.md) for version history.
+**0.8.0-draft** — See the [Changelog](changelog.md) for version history.
 
 ---
 


### PR DESCRIPTION
## Summary
- Updates the version displayed on the docs landing page from `0.6.0-draft` to `0.8.0-draft` to match the changelog

## Test plan
- [ ] Verify `docs/index.md` shows correct version matching `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)